### PR TITLE
Dependency upper limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,8 @@
+## Unreleased
+- Remove upper limits on development dependencies
+
+## 0.3.1
+- Update changelog link in the gemspec file to reflect the default branch name change from `master` to `main`
+
 ## 0.3.0  
 - Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.0
 - Remove upper limits on development dependencies
 
 ## 0.3.1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ my_report.has_messages?('Full Task Report', 'Tasks')
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, merge changes into main, pull changes locally into then main branch and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/lib/report_action/version.rb
+++ b/lib/report_action/version.rb
@@ -1,3 +1,3 @@
 module ReportAction
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/report_action.gemspec
+++ b/report_action.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "bundler", ">= 1.17"
+  spec.add_development_dependency "rake", ">= 12.0"
+  spec.add_development_dependency "minitest", ">= 5.0"
 end


### PR DESCRIPTION
This removes the upper limits on the development dependencies, provides better instructions for releasing a new version of the gem and updates the CHANGELOG with the missing entry for the 0.3.1 release and the entry for the upcoming 0.4.0 release.