### PR TITLE
Add ci

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -17,13 +17,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby-version: [ '3.1', '3.0', '2.7' ]
+
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
 
         with:
-          ruby-version: '3.0'
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,0 +1,30 @@
+name: test_suite
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '*.md'
+      - 'bin/*'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '*.md'
+      - 'bin/*'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+
+        with:
+          ruby-version: '3.0'
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.5.3
-before_install: gem install bundler -v 1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add GitHub action for running the test suite
+
 ## 0.4.0
 - Remove upper limits on development dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ReportAction
 
+![tests](https://github.com/CraigJZ/report_action/workflows/test_suite/badge.svg)
+
 A collection of tools for structuring and building simple reports, which can be extracted as a structure or as text with html.
 
 ## Installation


### PR DESCRIPTION
This branch introduces Github actions and adds a check to run the full test suite on pushes to main and and PRs targeting main. It will run against Ruby 3.1, 3.0 and 2.7.