### PR TITLE
Support ruby 3.3

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '3.3', '3.2', '3.1', '3.0' ]
+        ruby-version: [ '3.3', '3.2', '3.1' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '3.2', '3.1', '3.0', '2.7' ]
+        ruby-version: [ '3.3', '3.2', '3.1', '3.0' ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This branch adds Ruby 3.3 to the ruby-version Matrix and removes Ruby 2.7 and Ruby 3.0.

Ruby 2.7 was end of life on 3/31/23 and Ruby 3.0 was end of life on 4/23/24.